### PR TITLE
Support CommonJS and exclusion of directories/modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,18 @@ docs](https://babeljs.io/docs/en/options#overrides). You can also define
 [overrides](https://babeljs.io/docs/en/options#overrides) for more fine-grained
 rules.
 
-You can use this to prevent the plugin from mocking imports in test modules
-for example.
+As a convenience, the plugin by default skips any files in directories named
+"test", "__tests__" or subdirectories of directories with those names. This
+can be configured using the `excludeDirs` option.
 
 ### Options
 
 The plugin supports the following options:
+
+`excludeDirs`
+
+An array of directory names (eg. "tests") whose modules are excluded from
+this transformation by default.
 
 `excludeImportsFromModules`
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Babel plugin that modifies modules to enable mocking of their dependencies. The plugin was written with the following goals:
 
-- Provide a simple interface for mocking ES module imports
+- Provide a simple interface for mocking ES and CommonJS (`require`) module imports
 - Work when running tests in Node with any test runner or in the browser when
   using any bundler (Browserify, Webpack etc.) or no bunder at all
 - Minimize the amount of extra code added to modules, since extra code
@@ -140,6 +140,24 @@ rules.
 
 You can use this to prevent the plugin from mocking imports in test modules
 for example.
+
+### CommonJS support
+
+The plugin has basic support for CommonJS. It will recognize the
+following patterns as imports:
+
+```js
+var foo = require('./foo');
+var { foo } = require('./foo');
+var { foo: bar } = require('./foo');
+```
+
+Where `var` may also be `const` or `let`. If the `require` is wrapped or
+contained within an expression it will not be processed.
+
+When processing a CommonJS module the plugin still emits ES6 `import` and
+`export` declarations, so transforming of ES6 `import`/`export` statements
+to CommonJS must be enabled in Babel.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ rules.
 You can use this to prevent the plugin from mocking imports in test modules
 for example.
 
+### Options
+
+The plugin supports the following options:
+
+`excludeImportsFromModules`
+
+An array of module names which should be ignored when processing imports.
+Any imports from these modules will not be mockable.
+Default: `["proxyquire"]`.
+
 ### CommonJS support
 
 The plugin has basic support for CommonJS. It will recognize the

--- a/index.js
+++ b/index.js
@@ -117,6 +117,11 @@ module.exports = ({types: t}) => {
           return;
         }
 
+        // Ignore non-top level require expressions.
+        if (varDecl.parentPath.parent.type !== 'Program') {
+          return;
+        }
+
         state.lastImport = varDecl.findParent(p => p.isVariableDeclaration());
 
         // `var aModule = require("a-module")`

--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ module.exports = ({types: t}) => {
         const id = varDecl.node.id;
         if (id.type === 'Identifier') {
           state.importMeta.set(id, {
-            symbol: '*',
+            symbol: '<CJS>',
             source,
             value: id,
           });

--- a/index.js
+++ b/index.js
@@ -196,12 +196,10 @@ module.exports = ({types: t}) => {
         }
 
         // Ignore the reference in the generated `$imports` variable declaration.
-        const newExprParent = child.findParent(p => p.isNewExpression());
-        if (
-          newExprParent &&
-          t.isIdentifier(newExprParent.node.callee) &&
-          newExprParent.node.callee.name === 'ImportMap'
-        ) {
+        const varDeclParent = child.findParent(p => p.isVariableDeclarator());
+        if (varDeclParent &&
+            varDeclParent.node.id.type === 'Identifier' &&
+            varDeclParent.node.id.name === '$imports') {
           return;
         }
 

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -98,6 +98,15 @@ describe("helpers", () => {
         map.$mock({ "./Widget": MockWidget });
         assert.equal(map.Widget, MockWidget);
       });
+
+      it("mocks symbols imported via CommonJS imports", () => {
+        const map = new ImportMap({
+          Widget: ["./Widget", "<CJS>", function Widget() {}]
+        });
+        const MockWidget = () => {};
+        map.$mock({ "./Widget": MockWidget });
+        assert.equal(map.Widget, MockWidget);
+      });
     });
 
     describe("$restore", () => {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -6,8 +6,12 @@ const { assert } = require("chai");
 function importsDecl(init) {
   return `
 import { ImportMap } from "babel-plugin-mockable-imports/lib/helpers";
-export const $imports = new ImportMap(${init});
+const $imports = new ImportMap(${init});
 `.trim();
+}
+
+function trailer() {
+  return "export { $imports };";
 }
 
 const fixtures = [
@@ -23,6 +27,7 @@ ${importsDecl(`{
   ident: ["a-module", "ident", ident]
 }`)}
 $imports.ident();
+${trailer()}
 `
   },
   {
@@ -37,6 +42,7 @@ ${importsDecl(`{
   ident: ["a-module", "default", ident]
 }`)}
 $imports.ident();
+${trailer()}
 `
   },
   {
@@ -51,6 +57,7 @@ ${importsDecl(`{
   aModule: ["a-module", "*", aModule]
 }`)}
 $imports.aModule.ident();
+${trailer()}
 `
   },
   {
@@ -84,6 +91,8 @@ ${importsDecl(`{
 function MyComponent() {
   return <$imports.Widget arg="value" />;
 }
+
+${trailer()}
 `
   },
   {
@@ -106,6 +115,7 @@ ${importsDecl(`{
   foo: ["a-module", "foo", foo]
 }`)}
 export { foo };
+${trailer()}
 `
   },
   {
@@ -124,7 +134,62 @@ ${importsDecl(`{
 
 function MyComponent() {
   return <$imports.widgets.Widget />;
-}`
+}
+
+${trailer()}
+`
+  },
+  {
+    description: "CommonJS default or namespace imports",
+    code: `
+var foo = require('./foo');
+foo();
+`,
+    output: `
+var foo = require('./foo');
+
+${importsDecl(`{
+  foo: ["./foo", "*", foo]
+}`)}
+$imports.foo();
+${trailer()}
+`
+  },
+  {
+    description: "CommonJS object pattern imports",
+    code: `
+var { foo } = require('./foo');
+foo();
+`,
+    output: `
+var {
+  foo
+} = require('./foo');
+
+${importsDecl(`{
+  foo: ["./foo", "foo", foo]
+}`)}
+$imports.foo();
+${trailer()}
+`
+  },
+  {
+    description: "CommonJS object pattern imports with rename",
+    code: `
+var { bar: foo } = require('./foo');
+foo();
+`,
+    output: `
+var {
+  bar: foo
+} = require('./foo');
+
+${importsDecl(`{
+  foo: ["./foo", "bar", foo]
+}`)}
+$imports.foo();
+${trailer()}
+`
   }
 ];
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -149,7 +149,7 @@ foo();
 var foo = require('./foo');
 
 ${importsDecl(`{
-  foo: ["./foo", "*", foo]
+  foo: ["./foo", "<CJS>", foo]
 }`)}
 $imports.foo();
 ${trailer()}
@@ -214,7 +214,7 @@ module.exports = bar;
 var foo = require('./foo');
 
 ${importsDecl(`{
-  foo: ["./foo", "*", foo]
+  foo: ["./foo", "<CJS>", foo]
 }`)}
 
 function bar() {
@@ -235,7 +235,7 @@ foo();
     output: `
 var foo = (true, require('./foo'));
 ${importsDecl(`{
-  foo: ["./foo", "*", foo]
+  foo: ["./foo", "<CJS>", foo]
 }`)}
 $imports.foo();
 ${trailer()}`

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -254,4 +254,35 @@ ignoreMe();
 
     assert.equal(normalize(code), normalize(output));
   });
+
+  describe("dir-based exclusion", () => {
+    function doesTransformFile(filename, pluginOpts = {}) {
+      const code = `
+import * as foo from './foo';
+var foo2 = require('foo');
+foo();
+foo2();`;
+      const { code: output } = transform(code, {
+        plugins: [[pluginPath, pluginOpts]],
+        filename
+      });
+      return normalize(code) !== normalize(output);
+    }
+
+    it("does transform modules outside of test dirs", () => {
+      assert.isTrue(doesTransformFile("/Users/john/project/index.js"));
+    });
+
+    it("does not transform modules in test dirs by default", () => {
+      assert.isFalse(doesTransformFile("/Users/john/project/test/index.js"));
+    });
+
+    it("does not transform modules that match user-provided exclude list", () => {
+      assert.isFalse(
+        doesTransformFile("/Users/john/project/prueba/index.js", {
+          excludeDirs: ["prueba"]
+        })
+      );
+    });
+  });
 });

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -190,6 +190,18 @@ ${importsDecl(`{
 $imports.foo();
 ${trailer()}
 `
+  },
+  {
+    description: "non top-level CommonJS imports",
+    code: `
+function test() {
+  var foo = require('./foo');
+}`,
+    output: `
+function test() {
+  var foo = require('./foo');
+}
+`
   }
 ];
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -202,6 +202,43 @@ function test() {
   var foo = require('./foo');
 }
 `
+  },
+  {
+    description: "module with default CommonJS export",
+    code: `
+var foo = require('./foo');
+function bar() { foo() }
+module.exports = bar;
+`,
+    output: `
+var foo = require('./foo');
+
+${importsDecl(`{
+  foo: ["./foo", "*", foo]
+}`)}
+
+function bar() {
+  $imports.foo();
+}
+
+module.exports = bar;
+module.exports.$imports = $imports;
+${trailer()}
+`
+  },
+  {
+    description: "commom JS import wrapped in sequence",
+    code: `
+var foo = (true, require('./foo'));
+foo();
+`,
+    output: `
+var foo = (true, require('./foo'));
+${importsDecl(`{
+  foo: ["./foo", "*", foo]
+}`)}
+$imports.foo();
+${trailer()}`
   }
 ];
 


### PR DESCRIPTION
This PR implements the features needed to start using the plugin with Hypothesis projects and some other existing projects I have:

1. Support for CommonJS imports, for projects that have not yet transitioned to ES imports
2. Support for excluding imports from certain modules, for modules where this causes problems. This is mainly needed for "proxyquire", but may be useful for other things
3. Exclude files in test directories ("test", "__tests__" by default) from processing, as this is a waste of CPU cycles

----

**TODO**

- [x] Ensure that `$imports` gets exported correctly in modules that have a CommonJS default export (`modules.exports = Foo`). The CJS default export currently ends up overwriting the `$imports` export