### PR TITLE
Fix two common issues with CommonJS import handling

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -5,13 +5,27 @@ class MockingError extends Error {
 }
 
 class ImportMap {
-  constructor(imports) {
+  constructor(imports = {}) {
     /**
      * A mapping of import local name (or alias) to metadata about where
      * the import came from.
      */
     this.$meta = imports;
     this.$restore();
+  }
+
+  /**
+   * Register an import.
+   *
+   * The `value` of the import will become available as a property named
+   * `alias` on this instance.
+   */
+  $add(alias, source, symbol, value) {
+    if (isSpecialMethod(alias)) {
+      return;
+    }
+    this.$meta[alias] = [source, symbol, value];
+    this[alias] = value;
   }
 
   /**
@@ -81,9 +95,8 @@ class ImportMap {
    * This function does nothing if called when no mocks are active.
    */
   $restore() {
-    const proto = Object.getPrototypeOf(this);
     Object.keys(this.$meta).forEach(alias => {
-      if (proto.hasOwnProperty(alias)) {
+      if (isSpecialMethod(alias)) {
         // Skip imports which conflict with special methods.
         return;
       }
@@ -91,6 +104,10 @@ class ImportMap {
       this[alias] = value;
     });
   }
+}
+
+function isSpecialMethod(name) {
+  return ImportMap.prototype.hasOwnProperty(name);
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -372,4 +372,3 @@ module.exports = ({types: t}) => {
     },
   };
 };
-('use strict');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-mockable-imports",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/cli": "^7.4.3",
     "@babel/core": "^7.4.3",
     "@babel/plugin-syntax-jsx": "^7.2.0",
+    "@babel/plugin-transform-destructuring": "^7.4.3",
     "@babel/preset-env": "^7.4.3",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -27,6 +27,23 @@ describe("helpers", () => {
       assert.equal(map.$restore, ImportMap.prototype.$restore);
     });
 
+    describe("$add", () => {
+      it("adds a new property to the instance", () => {
+        const map = new ImportMap();
+        map.$add("foo", "./bar", "foo", 42);
+        assert.equal(map.foo, 42);
+        assert.deepEqual(map.$meta.foo, ["./bar", "foo", 42]);
+      });
+
+      ["$mock", "$restore", "$add"].forEach(method => {
+        it(`does not add a new property if the name is ${method}`, () => {
+          const map = new ImportMap();
+          map.$add(method, "./bar", "foo", 42);
+          assert.notEqual(map[method], 42);
+        });
+      });
+    });
+
     describe("$mock", () => {
       it("replaces all matching aliases with mock values", () => {
         const map = new ImportMap({

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -10,6 +10,17 @@ const $imports = new ImportMap(${init});
 `.trim();
 }
 
+function importHelper() {
+  return `
+import { ImportMap } from "babel-plugin-mockable-imports/lib/helpers";
+const $imports = new ImportMap();
+`.trim();
+}
+
+function importAdd(alias, source, symbol = alias, value = alias) {
+  return `$imports.$add("${alias}", "${source}", "${symbol}", ${value})`;
+}
+
 function trailer() {
   return "export { $imports };";
 }
@@ -23,9 +34,8 @@ ident();
 `,
     output: `
 import { ident } from 'a-module';
-${importsDecl(`{
-  ident: ["a-module", "ident", ident]
-}`)}
+${importHelper()}
+${importAdd("ident", "a-module")}
 $imports.ident();
 ${trailer()}
 `
@@ -38,9 +48,8 @@ ident();
 `,
     output: `
 import ident from 'a-module';
-${importsDecl(`{
-  ident: ["a-module", "default", ident]
-}`)}
+${importHelper()}
+${importAdd("ident", "a-module", "default")}
 $imports.ident();
 ${trailer()}
 `
@@ -53,9 +62,8 @@ aModule.ident();
 `,
     output: `
 import * as aModule from 'a-module';
-${importsDecl(`{
-  aModule: ["a-module", "*", aModule]
-}`)}
+${importHelper()}
+${importAdd("aModule", "a-module", "*")}
 $imports.aModule.ident();
 ${trailer()}
 `
@@ -84,9 +92,8 @@ function MyComponent() {
 }`,
     output: `
 import Widget from './Widget';
-${importsDecl(`{
-  Widget: ["./Widget", "default", Widget]
-}`)}
+${importHelper()}
+${importAdd("Widget", "./Widget", "default")}
 
 function MyComponent() {
   return <$imports.Widget arg="value" />;
@@ -111,9 +118,8 @@ import { foo } from 'a-module';
 export { foo }`,
     output: `
 import { foo } from 'a-module';
-${importsDecl(`{
-  foo: ["a-module", "foo", foo]
-}`)}
+${importHelper()}
+${importAdd("foo", "a-module")}
 export { foo };
 ${trailer()}
 `
@@ -128,9 +134,8 @@ function MyComponent() {
 }`,
     output: `
 import * as widgets from './widgets';
-${importsDecl(`{
-  widgets: ["./widgets", "*", widgets]
-}`)}
+${importHelper()}
+${importAdd("widgets", "./widgets", "*")}
 
 function MyComponent() {
   return <$imports.widgets.Widget />;
@@ -148,9 +153,8 @@ foo();
     output: `
 var foo = require('./foo');
 
-${importsDecl(`{
-  foo: ["./foo", "<CJS>", foo]
-}`)}
+${importHelper()}
+${importAdd("foo", "./foo", "<CJS>")}
 $imports.foo();
 ${trailer()}
 `
@@ -166,9 +170,8 @@ var {
   foo
 } = require('./foo');
 
-${importsDecl(`{
-  foo: ["./foo", "foo", foo]
-}`)}
+${importHelper()}
+${importAdd("foo", "./foo")}
 $imports.foo();
 ${trailer()}
 `
@@ -184,9 +187,8 @@ var {
   bar: foo
 } = require('./foo');
 
-${importsDecl(`{
-  foo: ["./foo", "bar", foo]
-}`)}
+${importHelper()}
+${importAdd("foo", "./foo", "bar")}
 $imports.foo();
 ${trailer()}
 `
@@ -213,9 +215,8 @@ module.exports = bar;
     output: `
 var foo = require('./foo');
 
-${importsDecl(`{
-  foo: ["./foo", "<CJS>", foo]
-}`)}
+${importHelper()}
+${importAdd("foo", "./foo", "<CJS>")}
 
 function bar() {
   $imports.foo();
@@ -234,9 +235,8 @@ foo();
 `,
     output: `
 var foo = (true, require('./foo'));
-${importsDecl(`{
-  foo: ["./foo", "<CJS>", foo]
-}`)}
+${importHelper()}
+${importAdd("foo", "./foo", "<CJS>")}
 $imports.foo();
 ${trailer()}`
   }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -228,7 +228,7 @@ ${trailer()}
 `
   },
   {
-    description: "commom JS import wrapped in sequence",
+    description: "common JS import wrapped in sequence",
     code: `
 var foo = (true, require('./foo'));
 foo();
@@ -239,6 +239,23 @@ ${importHelper()}
 ${importAdd("foo", "./foo", "<CJS>")}
 $imports.foo();
 ${trailer()}`
+  },
+  {
+    description: "common JS import with destructuring transform",
+    code: `
+var { foo } = require("./foo");
+foo();
+`,
+    output: `
+var _require = require("./foo"),
+    foo = _require.foo;
+
+${importHelper()}
+${importAdd("_require", "./foo", "<CJS>")}
+${importAdd("foo", "./foo")}
+$imports.foo();
+${trailer()}`,
+    plugins: ["@babel/plugin-transform-destructuring"]
   }
 ];
 
@@ -254,9 +271,11 @@ function normalize(code) {
 }
 
 describe("plugin", () => {
-  fixtures.forEach(({ description, code, output }) => {
+  fixtures.forEach(({ description, code, output, plugins = [] }) => {
     it(`generates expected code for ${description}`, () => {
-      const { code: actualOutput } = transform(code, options);
+      const options_ = { ...options };
+      options_.plugins = [...options_.plugins, ...plugins];
+      const { code: actualOutput } = transform(code, options_);
       assert.equal(actualOutput.trim(), output.trim());
     });
   });


### PR DESCRIPTION
Fix two common issues with CommonJS import handling:

1. The generated code previously relied on registering all imports at once. That could result in non-working code if the initialization of one-top level variable in a module depended on an import. For example, in:
   ```js
   var foo = require("./foo");
   var bar = foo.bar;
   var baz = require("./baz");
   ```

   The initialization of `bar` should be transformed to `$imports.foo.bar`, but this can't happen if the `$imports` var is initialized at the bottom of the imports list.
2. Destructuring in variable declarations (`var { foo } = require("./foo")`) was transformed down to ES5 before the plugin was able to process the destructuring pattern, to `var _foo = require("./foo"), foo = _foo.foo`. This prevented the plugin from registering `foo` as an import and replacing references to it elsewhere in the file.

The first issue is resolved by registering imports one at a time immediately after their declaration in generated code using a call to `$imports.$add`. The second issue is resolved by visiting the variable declaration in the main visitor to find require calls, instead of visiting the require call expression first.