### PR TITLE
Support CommonJS imports with separate var declaration and init

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -256,6 +256,18 @@ ${importAdd("foo", "./foo")}
 $imports.foo();
 ${trailer()}`,
     plugins: ["@babel/plugin-transform-destructuring"]
+  },
+  {
+    description: "common JS import with separate var decl and initialization",
+    code: `var foo; foo = require("./foo"); foo()`,
+    output: `
+var foo;
+${importHelper()}
+foo = require("./foo");
+${importAdd("foo", "./foo", "<CJS>")};
+$imports.foo();
+${trailer()}
+`
   }
 ];
 


### PR DESCRIPTION
One of the initial consumers of this plugin, hypothesis/client, still
uses CoffeeScript v1, which converts `<ident> = require(<module>)`
expressions at the top of the file to `var <ident>; ident = require(<module>)`.

It is possible that other code transforms might do a similar thing to
save a few bytes.

Add basic support for recognizing CommonJS imports declared this way.