### PR TITLE
Support passing a function to `$mock` for semi-automated mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,46 @@ $imports.$mock({
 });
 ```
 
+### Mocking all imports that match a pattern
+
+In some tests you may want to mock many dependencies in the same way, or ensure
+that all imports meeting certain criteria in a module are mocked consistently.
+
+You can pass a function to `$imports.$mock` which will be called with the
+source, symbol name and original value of each import. The result of the
+function will be used as the mock for that import if it is not `null`.
+
+For example, to mock all functions imported by a module, you can use:
+
+```js
+$imports.$mock((source, symbol, value) => {
+  if (typeof value === 'function') {
+    // Mock functions using Sinon.
+    return sinon.stub();
+  } else {
+    // Skip mocking objects, constants etc.
+    return null;
+  }
+});
+```
+
+To ensure that a test mocks every imported function, you can use:
+
+```js
+// Throw an error if any unmocked function is called.
+$imports.$mock((source, symbol, value) => {
+  if (typeof value === 'function') {
+    return () => throw new Error('Function not mocked');
+  }
+  return null;
+});
+
+// Setup mocks for expected imports.
+$imports.$mock({
+  './util': { doSomething: fakeDoSomething },
+});
+```
+
 ### Limiting mocking to specific files
 
 Babel allows the set of plugins applied to files to be configured on a per

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -124,6 +124,39 @@ describe("helpers", () => {
         map.$mock({ "./Widget": MockWidget });
         assert.equal(map.Widget, MockWidget);
       });
+
+      it("supports passing a function to `$mock`", () => {
+        const objectOne = {};
+        const map = new ImportMap({
+          functionOne: [
+            "./function-one",
+            "functionOne",
+            function functionOne() {}
+          ],
+          functionTwo: [
+            "./function-two",
+            "functionTwo",
+            function functionTwo() {}
+          ],
+          objectOne: ["./object-one", "default", objectOne]
+        });
+        const stubFunction = () => {};
+
+        // Call `$mock` with a function that mocks all function imports with
+        // a stub function.
+        map.$mock((source, symbol, value) => {
+          if (typeof value === "function") {
+            return stubFunction;
+          } else {
+            return null;
+          }
+        });
+
+        // Check that only the function imports were mocked.
+        assert.equal(map.functionOne, stubFunction);
+        assert.equal(map.functionTwo, stubFunction);
+        assert.equal(map.objectOne, objectOne);
+      });
     });
 
     describe("$restore", () => {


### PR DESCRIPTION
Since the `$imports` object added to each module by this plugin knows about all the imports of a module, it can enumerate them. Add support for passing a function to `$mock` which receives the (source, symbol, value) of each import and returns the mock to use, or `null` to avoid mocking.

This can be used to do things like:

- Mocking all imports that meet certain criteria (eg. functions, React components, imports from a certain module) in a consistent way
- Ensuring that all imports, or all imports matching a pattern, are mocked