### PR TITLE
Make generated `$imports.$add(...)` calls statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,14 +47,16 @@ module.exports = ({ types: t }) => {
    * Create an `$imports.$add(alias, source, symbol, value)` method call.
    */
   function createAddImportCall(alias, source, symbol, value) {
-    return t.callExpression(
-      t.memberExpression(t.identifier("$imports"), t.identifier("$add")),
-      [
-        t.stringLiteral(alias),
-        t.stringLiteral(source),
-        t.stringLiteral(symbol),
-        value
-      ]
+    return t.expressionStatement(
+      t.callExpression(
+        t.memberExpression(t.identifier("$imports"), t.identifier("$add")),
+        [
+          t.stringLiteral(alias),
+          t.stringLiteral(source),
+          t.stringLiteral(symbol),
+          value
+        ]
+      )
     );
   }
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -11,7 +11,7 @@ const $imports = new ImportMap();
 }
 
 function importAdd(alias, source, symbol = alias, value = alias) {
-  return `$imports.$add("${alias}", "${source}", "${symbol}", ${value})`;
+  return `$imports.$add("${alias}", "${source}", "${symbol}", ${value});`;
 }
 
 function trailer() {
@@ -256,7 +256,7 @@ ${trailer()}`,
 var foo;
 ${importHelper()}
 foo = require("./foo");
-${importAdd("foo", "./foo", "<CJS>")};
+${importAdd("foo", "./foo", "<CJS>")}
 $imports.foo();
 ${trailer()}
 `


### PR DESCRIPTION
Previously the generated `$imports.$add` calls were generated as just
`CallExpression`s instead of statements. Top-level items in a module
should all be statements or declarations per the ECMAScript spec. I'm
not entirely sure how Babel handles invalid ASTs but this caused
problems when the plugin was used together with
babel-plugin-transform-async-to-promises.