### PR TITLE
Do not treat function arguments to `$mock` as objects

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -66,6 +66,8 @@ class ImportMap {
         }
       });
       this.$mock(mocks);
+
+      return;
     }
 
     Object.keys(imports).forEach(source => {

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -157,6 +157,21 @@ describe("helpers", () => {
         assert.equal(map.functionTwo, stubFunction);
         assert.equal(map.objectOne, objectOne);
       });
+
+      it("does not process keys of `$mock` argument if it is a function", () => {
+        const map = new ImportMap({
+          foo: ["./foo", "foo", () => "original foo"]
+        });
+
+        const mocker = () => null;
+
+        // This should be ignored because `mocker` is a function.
+        mocker["./foo"] = { foo: () => "mocked foo" };
+
+        map.$mock(mocker);
+
+        assert.equal(map.foo(), "original foo");
+      });
     });
 
     describe("$restore", () => {


### PR DESCRIPTION
Add a missing `return` which caused `$mock` to run both the "function"
and "object" branches of logic if the passed object was a function.