### PR TITLE
Support selectively restoring mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,31 @@ As a convenience, the plugin by default skips any files in directories named
 `test` or `__tests__` or their subdirectories. This can be configured using the
 `excludeDirs` option.
 
+
+### Restoring specific mocks
+
+Calling `$imports.$restore()` will undo/restore all active mocks for a module. It is
+also possible to restore only specific mocks by passing an object which specifies
+the modules and symbols to un-mock. The object is in the same format as the
+argument to `$imports.$mock`, except the values are booleans indicating whether
+to restore the mock.
+
+```js
+// Restore all mocks for imports from the './some-widget' module. Other mocks are
+// left alone.
+$imports.$restore({
+  './some-widget': true
+});
+
+// Restore mocks for the "foo" symbol imported from the './utils' module. Other
+// mocks are left alone.
+$imports.$restore({
+  './utils': {
+    foo: true,
+  }
+});
+```
+
 ### Options
 
 The plugin supports the following options:

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -180,7 +180,8 @@ describe("helpers", () => {
         map = new ImportMap({
           first: ["a-module", "first", "original-first-value"],
           second: ["a-module", "second", "original-second-value"],
-          third: ["a-module", "first", "original-first-value"]
+          third: ["a-module", "first", "original-first-value"],
+          fourth: ["b-module", "foo", "original-foo-value"]
         });
       });
 
@@ -205,6 +206,38 @@ describe("helpers", () => {
         map.$restore();
 
         assert.equal(map.first, "original-first-value");
+      });
+
+      it("restores specified modules if an argument is passed", () => {
+        map.$mock({
+          "a-module": {
+            first: "new-first-value",
+            second: "new-second-value"
+          },
+          "b-module": {
+            foo: "new-foo-value"
+          }
+        });
+
+        map.$restore({ "a-module": true });
+
+        assert.equal(map.first, "original-first-value");
+        assert.equal(map.second, "original-second-value");
+        assert.equal(map.fourth, "new-foo-value");
+      });
+
+      it("restores specified symbols if an argument is passed", () => {
+        map.$mock({
+          "a-module": {
+            first: "new-first-value",
+            second: "new-second-value"
+          }
+        });
+
+        map.$restore({ "a-module": { first: true } });
+
+        assert.equal(map.first, "original-first-value");
+        assert.equal(map.second, "new-second-value");
       });
     });
   });


### PR DESCRIPTION
In some scenarios it may be useful to mock all/most imports during the
setup for every test and then selectively un-mock specific imports for a
particular test.

This commit adds support for passing an argument to `$imports.$restore`
to un-mock whole modules or specific imports:

```
$imports.$restore({
  // Unmock all imports from './a-module'.
  './a-module': true,

  // Unmock only "foo" from './b-module'.
  './b-module': { foo: true },
});
```