### PR TITLE
Handle identifier for import being renamed by another plugin

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -337,6 +337,37 @@ ${trailer()}
       "non-CommonJS import variable declaration (call expression init)",
     code: 'var foo = doSomething("bar");',
     output: 'var foo = doSomething("bar");'
+  },
+  {
+    description:
+      "Reference to import where local alias has been renamed by another Babel plugin",
+    code: `
+import { render } from "preact";
+
+var x = {
+  render: function () {
+    render();
+  }
+};
+`,
+    plugins: ["@babel/plugin-transform-function-name"],
+
+    // Note that the imported `render` function is renamed to `_render` by the
+    // @babel/plugin-transform-function-name plugin _after_ the `$imports.$add`
+    // call is generated. The generated `$imports.<symbol>` reference needs to
+    // refer to the original alias name (`render`) not the current name (`_render`)
+    // at the point where the function is called.
+    output: `
+import { render as _render } from "preact";
+${importHelper()}
+$imports.$add("render", "preact", "render", _render);
+var x = {
+  render: function render() {
+    $imports.render();
+  }
+};
+${trailer()}
+`
   }
 ];
 


### PR DESCRIPTION
Handle the case where an identifier referring to an import is renamed by
another Babel plugin after the `$imports.$add` call is generated for
that identifier but before the identifier is referenced in some later
context.

For example, given:

```js
import { render } from "preact";

var x = {
  render: function() {
    render();
  }
};
```

The @babel/plugin-transform-function-name plugin, if active, would transform the
code to:

```js
import { render as _render } from "preact";

var x = {
  render: function() {
    _render();
  }
};
```

When processing the call to `_render()` we need to generate a call to
`$imports.render()` rather than `$imports._render()` because earlier in
the module we will have generated a call to `$imports.$add("render",
"preact", "render", render)` where the first argument is the alias name.

The solution implemented here is to record the alias name used when
inserting the `$imports.$add` call and to use that alias name instead of
the identifier's current name when replacing later references to the
identifier.

Fixes #24