### PR TITLE
Exclude Rollup helper modules from mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,11 @@ this transformation by default.
 `excludeImportsFromModules`
 
 An array of module names which should be ignored when processing imports.
-Any imports from these modules will not be mockable.
-Default: `["proxyquire"]`.
+Any imports from these modules will not be mockable. Module names can be
+specified as strings (to match exactly) or regular expressions.
+
+By default this list includes imports from a few packages (eg. proxyquire,
+@rollup/plugin-babel) which are known not to work well with this plugin.
 
 ### CommonJS support
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -398,6 +398,9 @@ var proxyquire = require('proxyquire');
 import proxyquire2 from 'proxyquire';
 proxyquire(require);
 proxyquire2(require);
+
+var someHelper = require('\0rollupPluginBabelHelpers.js');
+someHelper();
 `;
     const { code: output } = transform(code, options);
     assert.equal(normalize(code), normalize(output));
@@ -409,6 +412,11 @@ import ignoreMe from 'ignore-me';
 const ignoreMe2 = require('ignore-me');
 ignoreMe();
 ignoreMe2();
+
+import excludeMe from 'exclude-me';
+const excludeMe2 = require('exclude-me');
+excludeMe();
+excludeMe2();
 `;
     const { code: output } = transform(code, {
       plugins: [
@@ -416,7 +424,7 @@ ignoreMe2();
         [
           pluginPath,
           {
-            excludeImportsFromModules: ["ignore-me"]
+            excludeImportsFromModules: ["ignore-me", /^exclude/]
           }
         ]
       ]


### PR DESCRIPTION
@rollup/plugin-babel may add an import of `\0rollupPluginHelpers.js` at
the top of a module in a way that can lead to usage of the `$imports`
helper generated by this plugin before its declaration. Since there is
no value in mocking this import, this commit resolves the issue by
adding these helper modules to the plugin's exclusion list. In the
process the `excludeImportsFromModules` option's syntax was expanded to
support regex patterns rather than just strings.