### PR TITLE
Register `$imports` declaration in Babel's scope tracker

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,7 +263,8 @@ export default ({ types: t }) => {
 
           // Insert `$imports` declaration below last import.
           const insertedNodes = body[0].insertAfter(helperImport);
-          insertedNodes[0].insertAfter($importsDecl);
+          const [varPath] = insertedNodes[0].insertAfter($importsDecl);
+          path.scope.registerDeclaration(varPath);
 
           // Insert `export { $imports }` at the end of the file. The reason for
           // inserting here is that this gets converted to `exports.$imports =


### PR DESCRIPTION
This fixes a warning when using this plugin in projects that also use
Babel's TypeScript support.

I haven't been able to find much in the way of documentation on how Babel's "scope tracker" works or how it interacts with methods for inserting nodes in the AST. However the change here mirrors patterns seen in official Babel plugins and commits referenced in https://github.com/babel/babel/issues/10264.